### PR TITLE
Add Go Codespaces (devcontainer) configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "Go Basic E-commerce",
+  "image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm", // Using a common Go image that includes 1.22
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.22" // Explicitly setting Go version for the feature as well
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "go.toolsManagement.autoUpdate": true,
+        "go.useLanguageServer": true,
+        "go.goroot": "/usr/local/go", // Typical Go root in these containers
+        "go.gopath": "/go" // Typical Go path
+      },
+      "extensions": [
+        "golang.Go",
+        "ms-azuretools.vscode-docker",
+        "github.codespaces",
+        "ms-vscode.makefile-tools" // If you use Makefiles
+      ]
+    }
+  },
+  "forwardPorts": [
+    8080 // Forward the application port
+  ],
+  "postCreateCommand": "go mod download", // Download dependencies after container creation
+  "remoteUser": "vscode" // Or "root" if you need root privileges by default
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This commit introduces a development container configuration for GitHub Codespaces, making it easier for you to set up a consistent development environment for this Go project.

Includes:
- A `.devcontainer/devcontainer.json` file specifying:
  - A Go 1.22 base image.
  - VS Code settings for Go development.
  - Recommended VS Code extensions (Go, Docker, Codespaces).
  - Port forwarding for the application (port 8080).
  - A `postCreateCommand` to automatically download Go modules.
- A `.gitattributes` file to ensure consistent LF line endings across different environments.

This setup allows you to quickly get started with a pre-configured environment in GitHub Codespaces.